### PR TITLE
OCM-7448 | chore: Remove useless info from create subnet example

### DIFF
--- a/cmd/rosa-support/create/subnets/cmd.go
+++ b/cmd/rosa-support/create/subnets/cmd.go
@@ -21,7 +21,7 @@ var Cmd = &cobra.Command{
 	Use:   "subnets",
 	Short: "Create subnets",
 	Long:  "Create subnets.",
-	Example: `  # Create a pair of subnets with prefix 'mysubnet-' in region 'us-east-2'
+	Example: `  # Create a pair of subnets in region 'us-east-2'
   rosa-support create subnets --region us-east-2 --vpc-id <vpc id> --availability-zones <AZs>`,
 
 	Run: run,


### PR DESCRIPTION
[OCM-7884](https://issues.redhat.com/browse/OCM-7884)

Removes info about prefix from example